### PR TITLE
Table formatting, bug in the logger

### DIFF
--- a/Account.cs
+++ b/Account.cs
@@ -1,4 +1,5 @@
-﻿using System.Transactions;
+﻿using System;
+using System.Transactions;
 
 namespace BankApp_GroupProject
 {
@@ -200,16 +201,31 @@ namespace BankApp_GroupProject
         {
             if (AccountHistory.Any() != true)
             {
-                Console.WriteLine("\nDu har för närvarande inga genomförda kontohändelser.\n");
+                Console.WriteLine($"\nInga kontohändelser finns på {GetAccountType(this)}t.\n");
             }
             else
             {
                 foreach (var item in AccountHistory)
                 {
-                    Console.WriteLine($"{item.SourceAcc}\t{item.SourceCurrency}\t{item.TransactionAmount}" +
-                        $"\t\t{item.TransactionType}\t{item.SourceAccBalance}\t\t{item.TransactionDate}");
+                    string s = item.TransactionType;
+
+                    Console.WriteLine($"{item.SourceAcc}\t" +
+                        $"{item.SourceCurrency}\t" +
+                        $"{ExchangeManager.Exchange.ConvertAmount(item.TransactionAmount)}\t\t" +
+                        $"{item.TransactionType}{StringCheck(s)}" +
+                        $"{ExchangeManager.Exchange.ConvertAmount(item.SourceAccBalance)}\t\t" +
+                        $"{item.TransactionDate}");
                 }
             }
+        }
+
+        //Method just for formatting the tabs in the printouts.
+        //If the string is to short it will mess with the columns,
+        //For example "Lån" in TransactionType.
+        public string StringCheck(string s) 
+        {
+            if (s.Length < 9) { return "\t\t"; }
+            else { return "\t";}
         }
     }
 }

--- a/Customer.cs
+++ b/Customer.cs
@@ -586,7 +586,7 @@ namespace BankApp_GroupProject
 
                         // Both transactions (debit & credit) are logged to the list of transactions.
                         Transaction f1 = new(transferAccount, originalTransferAmount, "Överföring", true); // Debit
-                        Transaction t1 = new(accountFirstIndex, originalTransferAmount, "Överföring", false); // Credit
+                        Transaction t1 = new(accountFirstIndex, transferAmount, "Överföring", false); // Credit
 
                         transferComplete = true;
                         break;
@@ -617,7 +617,7 @@ namespace BankApp_GroupProject
 
                         // Both transactions (debit & credit) are logged to the list of transactions.
                         Transaction f2 = new(transferAccount, originalTransferAmount, "Överföring", true); // Debit
-                        Transaction t2 = new(accountSecondIndex, originalTransferAmount, "Överföring", false); // Credit
+                        Transaction t2 = new(accountSecondIndex, transferAmount, "Överföring", false); // Credit
 
                         transferComplete = true;
                         break;
@@ -911,7 +911,7 @@ namespace BankApp_GroupProject
                     Console.WriteLine(ascii.Header());
 
                     Console.WriteLine("Kontonr.\tSaldo\t\tValuta\tLåneskuld" +
-                        "\n=================================================");
+                        "\n==============================================================");
 
                     // Here are the customers accounts being displayed along with details for the 
                     // account number, balance, currency and if they already have a debt to the bank.
@@ -919,19 +919,22 @@ namespace BankApp_GroupProject
                     {
                         totalBalance = 0;
 
+                        //Converts Balance to int rounded up, when displaying in table
+                        int displayBalance = ExchangeManager.Exchange.ConvertAmount(item.Balance);
+
                         if (item.Debt == 0)
                         {
-                            Console.Write($"{item.AccountNumber}\t{item.Balance}\t\t{item.Currency}\t{item.Debt:-}");
+                            Console.Write($"{item.AccountNumber}\t{displayBalance}\t\t{item.Currency}\t{item.Debt:-}");
                         }
                         else
                         {
                             if (item.Type == AccountType.Checking)
                             {
-                                Console.Write($"{item.AccountNumber}\t{item.Balance}\t\t{item.Currency}\t{item.Debt}\n");
+                                Console.Write($"{item.AccountNumber}\t{displayBalance}\t\t{item.Currency}\t{item.Debt}\n");
                             }
                             else
                             {
-                                Console.Write($"{item.AccountNumber}\t{item.Balance}\t\t{item.Currency}\t-");
+                                Console.Write($"{item.AccountNumber}\t{displayBalance}\t\t{item.Currency}\t-");
                             }
                         }
                         Console.WriteLine();
@@ -963,7 +966,7 @@ namespace BankApp_GroupProject
                         }
                     }
 
-                    Console.WriteLine("=================================================");
+                    Console.WriteLine("==============================================================");
 
                     // The customers total balance is printed out along with how much money 
                     // the customer can loan (max five times the amount of total balance). 
@@ -1029,9 +1032,6 @@ namespace BankApp_GroupProject
                                 "\nDin totala månadskostnad kommer att vara " + Math.Round(monthlyDebt, 2) + " kr/månad i " + loanTime * 12 + " månader.");
                            
                             decimal loan = Convert.ToDecimal(loanAmount);
-
-                            // The transactions for the loan is being logged.
-                            Transaction t1 = new(account, loan, "Lån", false);
                            
                             // The loan is stored in the property Debt.
                             account.Debt += Convert.ToDecimal(loanAmount);
@@ -1042,6 +1042,9 @@ namespace BankApp_GroupProject
 
                             // This message shows the customer the total sum of their account on which the loan is being deposit.
                             Console.WriteLine($"Totalsumman på ditt lönekonto: {account.Balance} kr.");
+
+                            // The transactions for the loan is being logged.
+                            Transaction t1 = new(account, loan, "Lån", false);
 
                             Console.Write("\nTryck \"ENTER\" för att återgå till föregående meny.");
                             Console.ReadKey();
@@ -1074,7 +1077,7 @@ namespace BankApp_GroupProject
             foreach (var account in CustomerAccounts)
             {
                 Console.WriteLine($"\nKonto\t\tValuta\tBelopp\t\tHändelse\tSaldo\t\tDatum");
-                Console.WriteLine($"===================================================================================");
+                Console.WriteLine($"====================================================================================");
                 account.PrintAccountHistory();
             }
 

--- a/ExchangeManager.cs
+++ b/ExchangeManager.cs
@@ -76,7 +76,7 @@ namespace BankApp_GroupProject
             decimal sourceRate = Currencies[sourceCurrency];
             decimal targetRate = Currencies[targetCurrency];
 
-            decimal result = Math.Round(userAmount * (sourceRate / targetRate), 2);
+            decimal result = Math.Round(userAmount * (sourceRate / targetRate), 1);
 
             return result;
         }
@@ -88,7 +88,7 @@ namespace BankApp_GroupProject
             decimal sourceRate = Currencies[sourceCurrency];
             decimal targetRate = Currencies[targetCurrency];
 
-            decimal result = Math.Round(userAmount * (sourceRate / targetRate), 2);
+            decimal result = Math.Round(userAmount * (sourceRate / targetRate), 1);
 
             Console.WriteLine($"Konverterar {userAmount} {sourceCurrency} till {targetCurrency}.");
             Console.WriteLine($"Växlingskurs {sourceCurrency}: {sourceRate}");
@@ -122,6 +122,14 @@ namespace BankApp_GroupProject
                     Console.ReadKey();
                 }
             }
+        }
+
+        //Method for taking away decimals in amounts when printed
+        //in tables, to avoid messing with the tabs when the amount is big
+        public int ConvertAmount(decimal amount)
+        {
+            int convertedAmount = Convert.ToInt32(Math.Round(amount));
+            return convertedAmount;
         }
     }
 }

--- a/Transaction.cs
+++ b/Transaction.cs
@@ -23,8 +23,8 @@ namespace BankApp_GroupProject
         public Transaction(Account sourceAccount, decimal transactionAmount,
                            string transactionType, bool isDebet)
         {
-            // When a new transaction is being logged from a account, 
-            // the debit shows the amount of money with a minus sign.
+            // If the transaction being logged is debet,
+            // this turns the amount negative 
             if (isDebet) { transactionAmount *= -1; }
 
             SourceAcc = sourceAccount.GetAccountType(sourceAccount);
@@ -35,8 +35,12 @@ namespace BankApp_GroupProject
             SourceAccBalance = sourceAccount.Balance;
             SourceCurrency = sourceAccount.Currency;
 
-            // Logs the transaction to AccountHistory.
-            sourceAccount.GetAccountHistory().Add(this);
+
+        // Logs the transaction to AccountHistory.
+        sourceAccount.GetAccountHistory().Add(this);
         }
+
+
+
     }
 }


### PR DESCRIPTION
- Made a method for converting amounts that are being displayed in the logger to int, to take away decimals that were messing with the tabs and pushing them forward. Also the gaps in the table had to be very wide to take account for decimals, which felt unnecessary.
- Fixed a bug in the logger that didn't calculate the balance properly when displayed, if the amounts were being converted from/to another currency.
- Changed the allowed decimal amount when rounded up to 1 in the exchange converter.
- Some cleaning in the formatting of tables to reflect the changes above